### PR TITLE
Add getters to several DXF graphical objects

### DIFF
--- a/lib/Arc.php
+++ b/lib/Arc.php
@@ -47,4 +47,12 @@ class Arc extends Circle {
     array_push($output, 51, $this->end);
     return implode(PHP_EOL, $output);
   }
+
+  public function getStart() {
+    return $this->start;
+  }
+
+  public function getEnd() {
+    return $this->end;
+  }
 }

--- a/lib/Circle.php
+++ b/lib/Circle.php
@@ -58,4 +58,20 @@ class Circle extends Entity {
     array_push($output, $this->point($this->extrusion, 200));
     return implode(PHP_EOL, $output);
   }
+
+  public function getThickness() {
+    return $this->thickness;
+  }
+
+  public function getPoint() {
+    return $this->point;
+  }
+
+  public function getRadius() {
+    return $this->radius;
+  }
+
+  public function getExtrusion() {
+    return $this->extrusion;
+  }
 }

--- a/lib/Ellipse.php
+++ b/lib/Ellipse.php
@@ -76,4 +76,28 @@ class Ellipse extends Entity {
     array_push($output, 42, $this->end);
     return implode(PHP_EOL, $output);
   }
+
+  public function getCenter() {
+    return $this->center;
+  }
+
+  public function getEndpoint() {
+    return $this->endpoint;
+  }
+
+  public function getExtrusion() {
+    return $this->extrusion;
+  }
+
+  public function getRatio() {
+    return $this->ratio;
+  }
+
+  public function getStart() {
+    return $this->start;
+  }
+
+  public function getEnd() {
+    return $this->end;
+  }
 }

--- a/lib/LWPolyline.php
+++ b/lib/LWPolyline.php
@@ -37,6 +37,10 @@ class LWPolyline extends Entity {
     $this->points[] = $point;
   }
 
+  public function getPoints() {
+    return $this->points;
+  }
+
   /**
    * Public function to render an entity, returns a string representation of
    * the entity.

--- a/lib/Line.php
+++ b/lib/Line.php
@@ -69,4 +69,20 @@ class Line extends Entity {
     array_push($output, $this->point($this->extrusion, 200));
     return implode(PHP_EOL, $output);
   }
+
+  public function getThickness() {
+    return $this->thickness;
+  }
+
+  public function getStart() {
+    return $this->start;
+  }
+
+  public function getEnd() {
+    return $this->end;
+  }
+
+  public function getExtrusion() {
+    return $this->extrusion;
+  }
 }

--- a/lib/Point.php
+++ b/lib/Point.php
@@ -58,4 +58,20 @@ class Point extends Entity {
     array_push($output, 50, $this->angle);
     return implode(PHP_EOL, $output);
   }
+
+  public function getThickness() {
+    return $this->thickness;
+  }
+
+  public function getPoint() {
+    return $this->point;
+  }
+
+  public function getExtrusion() {
+    return $this->extrusion;
+  }
+
+  public function getAngle() {
+    return $this->angle;
+  }
 }

--- a/lib/Polyline.php
+++ b/lib/Polyline.php
@@ -89,4 +89,16 @@ class Polyline extends Entity {
     array_push($output, $this->seqend->render());
     return implode(PHP_EOL, $output);
   }
+
+  public function getBase() {
+    return $this->base;
+  }
+
+  public function getPoints() {
+    return $this->points;
+  }
+
+  public function getDimension() {
+    return $this->dimension;
+  }
 }

--- a/lib/Spline.php
+++ b/lib/Spline.php
@@ -84,4 +84,28 @@ class Spline extends Entity {
 
     return implode(PHP_EOL, $output);
   }
+
+  public function getBase() {
+    return $this->base;
+  }
+
+  public function getStart() {
+    return $this->start;
+  }
+
+  public function getEnd() {
+    return $this->end;
+  }
+
+  public function getPoints() {
+    return $this->points;
+  }
+
+  public function getKnots() {
+    return $this->knots;
+  }
+
+  public function getDegree() {
+    return $this->degree;
+  }
 }

--- a/lib/Vertex.php
+++ b/lib/Vertex.php
@@ -68,4 +68,16 @@ class Vertex extends Entity {
     array_push($output, 70, $this->flagsToString());
     return implode(PHP_EOL, $output);
   }
+
+  public function getDimension() {
+    return $this->dimension;
+  }
+
+  public function getPoint() {
+    return $this->point;
+  }
+
+  public function getBulge() {
+    return $this->bulge;
+  }
 }


### PR DESCRIPTION
When reading a DXF file you want to access the properties of the graphical objects. This was impossible because there were no getters. This PR adds getters so these properties can be accessed.