### PR TITLE
Implement ARC DXF parsing

### DIFF
--- a/DXFighter.php
+++ b/DXFighter.php
@@ -20,6 +20,7 @@ use DXFighter\lib\AppID,
   DXFighter\lib\Style,
   DXFighter\lib\SystemVariable,
   DXFighter\lib\Table;
+use DXFighter\lib\Arc;
 use DXFighter\lib\Ellipse;
 use DXFighter\lib\Insert;
 use DXFighter\lib\Line;
@@ -408,7 +409,7 @@ class DXFighter {
     $entities = [];
     $entityType = '';
     $data = [];
-    $types = ['TEXT', 'LINE', 'ELLIPSE', 'SPLINE', 'INSERT'];
+    $types = ['TEXT', 'LINE', 'ELLIPSE', 'SPLINE', 'INSERT', 'ARC'];
     // TODO most entity types are still missing
     foreach ($values as $value) {
       if ($value['key'] == 0) {
@@ -581,6 +582,26 @@ class DXFighter {
         $polyline->move($move);
         $polyline->rotate($rotate);
         return $polyline;
+      case 'ARC':
+        $center = [$data[10], $data[20], $data[30]];
+        $thickness = $data[39] ? $data[39] : 0;
+        $extrusion = [
+          $data[210] ? $data[210] : 0,
+          $data[220] ? $data[220] : 0,
+          $data[230] ? $data[230] : 1
+        ];
+        $arc = new Arc(
+          $center,
+          $data[40],
+          $data[50],
+          $data[51],
+          $thickness,
+          $extrusion
+        );
+
+        $arc->move($move);
+
+        return $arc;
     }
     return false;
   }

--- a/lib/Arc.php
+++ b/lib/Arc.php
@@ -23,7 +23,7 @@ class Arc extends Circle {
    * @param $point
    * @param $radius
    * @param int $start
-   * @param array $end
+   * @param int $end
    * @param int $thickness
    * @param array $extrusion
    */


### PR DESCRIPTION
I have used the documentation here: http://help.autodesk.com/view/OARX/2018/ENU/?guid=GUID-107CB04F-AD4D-4D2F-8EC9-AC90888063AB. I've tested this with a DXF file with a ton of different arcs in different directions and they are all parsed properly.