### PR TITLE
Add bulge to parsed vertices

### DIFF
--- a/DXFighter.php
+++ b/DXFighter.php
@@ -578,7 +578,8 @@ class DXFighter {
           }
         }
         foreach($data['points'] as $point) {
-          $polyline->addPoint([$point[10], $point[20], $point[30]]);
+          $bulge = isset($point[42]) ? $point[42] : 0;
+          $polyline->addPoint([$point[10], $point[20], $point[30]], $bulge);
         }
         $polyline->move($move);
         $polyline->rotate($rotate);


### PR DESCRIPTION
The parsed vertices in a Polyline didn't include the correct bulge based on the DXF. This adds the bulge to the Vertex objects.

See http://help.autodesk.com/view/OARX/2018/ENU/?guid=GUID-0741E831-599E-4CBF-91E1-8ADBCFD6556D.