### PR TITLE
Add support for parsing LWPolyline entities

### DIFF
--- a/DXFighter.php
+++ b/DXFighter.php
@@ -25,6 +25,7 @@ use DXFighter\lib\Circle;
 use DXFighter\lib\Ellipse;
 use DXFighter\lib\Insert;
 use DXFighter\lib\Line;
+use DXFighter\lib\LWPolyline;
 use DXFighter\lib\Polyline;
 use DXFighter\lib\Spline;
 use DXFighter\lib\Text;
@@ -410,11 +411,15 @@ class DXFighter {
     $entities = [];
     $entityType = '';
     $data = [];
-    $types = ['TEXT', 'LINE', 'ELLIPSE', 'SPLINE', 'INSERT', 'ARC', 'CIRCLE'];
+    $types = ['TEXT', 'LINE', 'ELLIPSE', 'SPLINE', 'INSERT', 'ARC', 'CIRCLE', 'LWPOLYLINE'];
     // TODO most entity types are still missing
     foreach ($values as $value) {
       if ($value['key'] == 0) {
-        if ((in_array($entityType, $types) && !empty($data)) || in_array($entityType, ['POLYLINE', 'VERTEX']) && $value['value'] == 'SEQEND') {
+        // This condition happens at the end of an entity
+        if (
+          (in_array($entityType, $types) && !empty($data)) ||
+          in_array($entityType, ['POLYLINE', 'VERTEX']) && $value['value'] == 'SEQEND'
+        ) {
           $entity = $this->addReadEntity($entityType, $data, $move, $rotate);
           if ($entity) {
             $entities[] = $entity;
@@ -429,6 +434,9 @@ class DXFighter {
           $data['knots'] = [];
           $data['points'] = [];
         }
+        if ($value['value'] == 'LWPOLYLINE') {
+          $data['points'] = [];
+        }
       } else {
         if ($entityType == 'SPLINE' && in_array($value['key'], [10, 20, 30, 40])) {
           switch ($value['key']) {
@@ -441,6 +449,16 @@ class DXFighter {
               break;
             case 40:
               $data['knots'][] = $value['value'];
+              break;
+          }
+        } elseif ($entityType == 'LWPOLYLINE' && in_array($value['key'], [10, 20, 42])) {
+          switch ($value['key']) {
+            case 10:
+              $data['points'][] = [10 => $value['value'], 20 => 0, 42 => 0];
+              break;
+            case 20:
+            case 42:
+              $data['points'][sizeof($data['points']) -1 ][$value['key']] = $value['value'];
               break;
           }
         } elseif (in_array($entityType, $types) || $entityType == 'POLYLINE') {
@@ -548,10 +566,14 @@ class DXFighter {
         $insert = new Insert($data[2]);
         $insert->move($move);
         return $insert;
+      case 'LWPOLYLINE':
       case 'POLYLINE':
       case 'VERTEX':
         if (isset($data[100])) {
           switch ($data[100]) {
+            case 'AcDbPolyline':
+              $polyline = new LWPolyline();
+              break;
             case 'AcDb2dPolyline':
               $polyline = new Polyline(2);
               break;

--- a/lib/LWPolyline.php
+++ b/lib/LWPolyline.php
@@ -16,6 +16,7 @@ namespace DXFighter\lib;
  */
 class LWPolyline extends Entity {
   protected $points = array();
+  protected $bulges = array();
   protected $dimension;
 
   /**
@@ -33,13 +34,39 @@ class LWPolyline extends Entity {
    * Add a point to the LWPolyline
    * @param array $point
    */
-  public function addPoint($point) {
+  public function addPoint($point, $bulge = 0) {
     $this->points[] = $point;
+    $this->bulges[] = $bulge;
     return $this;
   }
 
   public function getPoints() {
     return $this->points;
+  }
+
+  public function getBulges() {
+    return $this->bulges;
+  }
+
+  /**
+   * Public function to move a Polyline entity
+   * @param array $move vector to move the entity with
+   */
+  public function move($move) {
+    foreach ($this->points as &$point) {
+      $this->movePoint($point, $move);
+    }
+  }
+
+  /**
+   * Public function to rotate all points of a polyline
+   * @param int $rotate degree value used for the rotation
+   * @param array $rotationCenter center point of the rotation
+   */
+  public function rotate($rotate, $rotationCenter = array(0, 0, 0)) {
+    foreach ($this->points as &$point) {
+      $this->rotatePoint($point, $rotationCenter, deg2rad($rotate));
+    }
   }
 
   /**
@@ -53,8 +80,9 @@ class LWPolyline extends Entity {
     array_push($output, 90, count($this->points));
     array_push($output, 70, $this->flagsToString());
 
-    foreach ($this->points as $point) {
+    foreach ($this->points as $i => $point) {
       array_push($output, $this->point($point));
+      array_push($output, 42, $this->bulges[$i]);
     }
 
     return implode(PHP_EOL, $output);


### PR DESCRIPTION
This is a newer way to save polylines which requires less disk space. It is only in 2D and it contains the point inline instead of via separate Vertex entities. For that reason save the bulges in a separate bulges array.

See also http://help.autodesk.com/view/OARX/2018/ENU/?guid=GUID-748FC305-F3F2-4F74-825A-61F04D757A50. https://ezdxf.readthedocs.io/en/stable/dxfentities/lwpolyline.html was also helpful.