### PR TITLE
Implement full INSERT support

### DIFF
--- a/DXFighter.php
+++ b/DXFighter.php
@@ -545,7 +545,14 @@ class DXFighter {
         }
         return $spline;
       case 'INSERT':
-        $insert = new Insert($data[2]);
+        $point = [$data[10], $data[20], $data[30]];
+        $scale = [
+          isset( $data[41] ) ? $data[41] : 1,
+          isset( $data[42] ) ? $data[42] : 1,
+          isset( $data[43] ) ? $data[43] : 1,
+        ];
+        $rotation = isset( $data[50] ) ? $data[50] : 0;
+        $insert = new Insert($data[2], $point, $scale, $rotation);
         $insert->move($move);
         return $insert;
       case 'POLYLINE':

--- a/lib/Insert.php
+++ b/lib/Insert.php
@@ -15,18 +15,25 @@ namespace DXFighter\lib;
  * @package DXFighter\lib
  */
 class Insert extends Entity {
-  protected $name;
+  protected $blockName;
   protected $point;
+  protected $scale;
+  protected $rotation;
 
   /**
    * Insert constructor.
-   * @param $name
-   * @param $point
+   *
+   * @param $blockName
+   * @param float[] $point
+   * @param float[] $scale The X, Y and Z scale factors.
+   * @param float $rotation
    */
-  function __construct($name, $point = [0, 0, 0]) {
+  function __construct( $blockName, $point = [0, 0, 0], $scale = [1, 1, 1], $rotation = 0) {
     $this->entityType = 'insert';
-    $this->name = $name;
-    $this->point = $point;
+    $this->blockName       = $blockName;
+    $this->point      = $point;
+    $this->scale      = $scale;
+    $this->rotation   = $rotation;
     parent::__construct();
   }
 
@@ -46,8 +53,12 @@ class Insert extends Entity {
   public function render() {
     $output = parent::render();
     array_push($output, 100, 'AcDbBlockReference');
-    array_push($output, 2, strtoupper($this->name));
+    array_push($output, 2, strtoupper($this->blockName));
     array_push($output, $this->point($this->point));
+    array_push($output, 41, $this->scale[0]);
+    array_push($output, 42, $this->scale[1]);
+    array_push($output, 43, $this->scale[2]);
+    array_push($output, 50, $this->rotation);
     return implode(PHP_EOL, $output);
   }
 }


### PR DESCRIPTION
The INSERT entity has scale and rotation properties that were missing. Those can now be parsed and written.

I renamed `name` to `blockName`, because there can be multiple inserts that refer to the same block. `name` has a validation that prevents those multiple inserts from being parsed.