### PR TITLE
Add getters to retrieve relevant DXF data

### DIFF
--- a/DXFighter.php
+++ b/DXFighter.php
@@ -55,11 +55,35 @@ spl_autoload_register(function($class) {
  */
 class DXFighter {
   protected $sections;
+
+  /**
+   * @var Section
+   */
   protected $header;
+
+  /**
+   * @var Section
+   */
   protected $classes;
+
+  /**
+   * @var Section
+   */
   protected $tables;
+
+  /**
+   * @var Section
+   */
   protected $blocks;
+
+  /**
+   * @var Section
+   */
   protected $entities;
+
+  /**
+   * @var Section
+   */
   protected $objects;
   protected $thumbnailImage;
 
@@ -166,6 +190,26 @@ class DXFighter {
    */
   public function addEntitiesFromFile($path, $move = [0,0,0], $rotate = 0) {
     $this->read($path, $move, $rotate);
+  }
+
+  public function getHeader() {
+    return $this->header;
+  }
+
+  public function getClasses() {
+    return $this->classes;
+  }
+
+  public function getTables() {
+    return $this->tables;
+  }
+
+  public function getBlocks() {
+    return $this->blocks;
+  }
+
+  public function getObject() {
+    return $this->objects;
   }
 
   public function getEntities() {

--- a/lib/Block.php
+++ b/lib/Block.php
@@ -38,6 +38,10 @@ class Block extends Entity {
     return $this->name;
   }
 
+  public function getEntities() {
+    return $this->entities;
+  }
+
   /**
    * Adds an Entity to the block
    *

--- a/lib/Insert.php
+++ b/lib/Insert.php
@@ -61,4 +61,20 @@ class Insert extends Entity {
     array_push($output, 50, $this->rotation);
     return implode(PHP_EOL, $output);
   }
+
+  public function getBlockName() {
+    return $this->blockName;
+  }
+
+  public function getPoint() {
+    return $this->point;
+  }
+
+  public function getScale() {
+    return $this->scale;
+  }
+
+  public function getRotation() {
+    return $this->rotation;
+  }
 }

--- a/lib/SystemVariable.php
+++ b/lib/SystemVariable.php
@@ -37,6 +37,10 @@ class SystemVariable extends BasicObject {
     return $this->variable;
   }
 
+  public function getValues() {
+    return $this->values;
+  }
+
   /**
    * Public function to render an entity, returns a string representation of
    * the entity.


### PR DESCRIPTION
These getters were missing which made it impossible to read the blocks
to handle inserts. Because the other information in a DXF is also
useful when reading them I added those getters too.

Builds upon https://github.com/enjoping/DXFighter/pull/12.