### PR TITLE
Fix non-strict key comparison

### DIFF
--- a/lib/Section.php
+++ b/lib/Section.php
@@ -39,7 +39,7 @@ class Section {
    */
   public function addItem(BasicObject $item) {
     $name = strtoupper($item->getName());
-    if (!in_array($name, $this->itemNames)) {
+    if (!in_array($name, $this->itemNames, true)) {
       $this->itemNames[] = $name;
       $this->items[] = $item;
     } elseif ($this->name == 'tables') {


### PR DESCRIPTION
With non-strict key comparison in the `in_array` function this can result in bugs. The specific case for DXFighter is because a hex variant is put in as the name. "2E2" is a valid hex value and occurs when there are enough entities (738). As "2E2" == "200" evaluates to true, when an entity with the name "200" is already present an entity with name "2E2" can no longer be added. The reason it evaluates to true is because 2E2 is scientific notation.